### PR TITLE
Customizing checksum calculation based on messag id.

### DIFF
--- a/howtos/howto101/dsl/schema.xml
+++ b/howtos/howto101/dsl/schema.xml
@@ -2,12 +2,16 @@
 <schema name="howto101" endian="big">
   <fields>
     <string name="MSG1Name" defaultValue="MSG1" />
+    <string name="MSG2Name" defaultValue="MSG2" />
+    <string name="MSG3Name" defaultValue="MSG3" />
 
     <int name="FlagField" type="uint8" />
     <int name="ChecksumField" type="uint64" />
 
     <enum name="PacketTypeField" type="uint8" semanticType="messageId" >
       <validValue name="MSG1PacketType" val="1" displayName="^MSG1Name" />
+      <validValue name="MSG2PacketType" val="2" displayName="^MSG2Name" />
+      <validValue name="MSG3PacketType" val="3" displayName="^MSG3Name" />
     </enum>
 </fields>
 
@@ -34,6 +38,14 @@
   <message name="MSG1" id="PacketTypeField.MSG1PacketType" displayName="^MSG1Name">
     <int name="uint1" type="uint32" />
     <int name="uint2" type="uint32" />
+  </message>
+
+  <message name="MSG2" id="PacketTypeField.MSG2PacketType" displayName="^MSG2Name">
+    <int name="uint1" type="uint32" />
+  </message>
+
+  <message name="MSG3" id="PacketTypeField.MSG3PacketType" displayName="^MSG3Name">
+    <int name="uint1" type="uint32" />
   </message>
 
 </schema>

--- a/howtos/howto101/dsl_src/include/howto101/frame/layer/PacketType.h
+++ b/howtos/howto101/dsl_src/include/howto101/frame/layer/PacketType.h
@@ -48,10 +48,6 @@ public:
     MsgIdType getMsgIdFromField(const Field& field)
     {
         auto id = field.field_packetTypeField().value();
-
-        // TODO: Use your code to analyze the presence of the checksum and upate
-        // its flag accordingly
-        Base::nextLayer().setChecksumExists(false);
         return id;
     }
 

--- a/howtos/howto101/src/ClientSession.cpp
+++ b/howtos/howto101/src/ClientSession.cpp
@@ -23,6 +23,34 @@ void ClientSession::handle(Msg1& msg)
     doNextStage();
 }
 
+void ClientSession::handle(Msg2& msg)
+{
+    std::cout << "Received message \"" << msg.doName() << "\" with ID=" << (unsigned)msg.doGetId() << '\n';
+    //printIntField(msg.field_f1());
+    std::cout << std::endl;
+
+    if (m_currentStage != CommsStage_Msg2) {
+        std::cerr << "ERROR: Unexpected stage" << std::endl;
+        return;
+    }
+
+    doNextStage();
+}
+
+void ClientSession::handle(Msg3& msg)
+{
+    std::cout << "Received message \"" << msg.doName() << "\" with ID=" << (unsigned)msg.doGetId() << '\n';
+    //printIntField(msg.field_f1());
+    std::cout << std::endl;
+
+    if (m_currentStage != CommsStage_Msg3) {
+        std::cerr << "ERROR: Unexpected stage" << std::endl;
+        return;
+    }
+
+    doNextStage();
+}
+
 void ClientSession::handle(Message& msg)
 {
     std::cerr << "ERROR: Received unexpected message \"" << msg.name() << " with ID=" << (unsigned)msg.getId() << std::endl;
@@ -106,6 +134,8 @@ void ClientSession::doNextStage()
     using NextSendFunc = void (ClientSession::*)();
     static const NextSendFunc Map[] = {
         /* CommsStage_Msg1 */ &ClientSession::sendMsg1,
+        /* CommsStage_Msg2 */ &ClientSession::sendMsg2,
+        /* CommsStage_Msg3 */ &ClientSession::sendMsg3,
     };
     static const std::size_t MapSize = std::extent<decltype(Map)>::value;
     static_assert(MapSize == CommsStage_NumOfValues, "Invalid Map");
@@ -121,16 +151,24 @@ void ClientSession::sendMsg1()
     msg.transportField_flagField().value() = 1;
     msg.field_uint1().value() = 1;
     msg.field_uint2().value() = 2;
-//    assert(msg.field_f3().isMissing()); // F3 is missing when default constructed
+    sendMessage(msg);
+}
 
-//    msg.field_f1().value() = 1111;
-//    msg.field_f2().value() = 2222;
-//    msg.field_f3().field().value() = 1234;
-//    msg.transportField_flags().setBitValue_B0(true);
+void ClientSession::sendMsg2()
+{
+    Msg2 msg;
 
-    msg.doRefresh(); // Bring everything into consistent state
-//    assert(msg.field_f3().doesExist()); // F3 must exist after refresh
-    
+    msg.transportField_flagField().value() = 1;
+    msg.field_uint1().value() = 3;
+    sendMessage(msg);
+}
+
+void ClientSession::sendMsg3()
+{
+    Msg3 msg;
+
+    //msg.transportField_flagField().value() = 1;
+    msg.field_uint1().value() = 4;
     sendMessage(msg);
 }
 

--- a/howtos/howto101/src/ClientSession.h
+++ b/howtos/howto101/src/ClientSession.h
@@ -37,9 +37,13 @@ public:
         
     // Definition of all the used message classes
     using Msg1 = howto101::message::MSG1<Message, ClientProtocolOptions>;
+    using Msg2 = howto101::message::MSG2<Message, ClientProtocolOptions>;
+    using Msg3 = howto101::message::MSG3<Message, ClientProtocolOptions>;
     
     // Handling functions for all the dispatched message objects
     void handle(Msg1& msg);
+    void handle(Msg2& msg);
+    void handle(Msg3& msg);
     void handle(Message& msg);
 
 protected:
@@ -50,12 +54,16 @@ private:
     enum CommsStage
     {
         CommsStage_Msg1,
+        CommsStage_Msg2,
+        CommsStage_Msg3,
         CommsStage_NumOfValues
     };
 
     void sendMessage(const Message& msg);
     void doNextStage();
     void sendMsg1();
+    void sendMsg2();
+    void sendMsg3();
 
     // Client specific frame 
     using Frame = 


### PR DESCRIPTION
The overriding "calculateChecksum()" member function was added to the Checksum layer. It is required only if the checksum calculation algorithm differs for different message IDs, like the ones I added to the schema. If the checksum calculation algorithm does not differ, the default implementation does proper job of invoking the custom checksum calculation algorithm passed as a template parameter. Also note that the "calculateChecksum()" member function is called only for those messages that require calculation (the filtering is performed inside doRead() and doWrite()). Also note that the iterator and length passed to the calculateChecksum() contain information about the wrapped layers, i.e. only payload. There is no need to do extra manipulation to the iterator and/or length parameters.

Also note that the Checksum layer in your case has all the relevant information, i.e. the message object is already constructed and can be used to retrieve the message ID, no need to have extra analysis in the "PacketType" layer. I removed the relevant functionality.